### PR TITLE
The ender chest problem

### DIFF
--- a/AlmostHardcoreMinecraft/src/org/c0z3n/AlmostHardcore.java
+++ b/AlmostHardcoreMinecraft/src/org/c0z3n/AlmostHardcore.java
@@ -60,14 +60,14 @@ public class AlmostHardcore extends JavaPlugin{
 				hardcorePlayer hcp = db.find(hardcorePlayer.class).where().eq("id", player.getUniqueId()).findUnique();
 				hcp.addDeath();
 				hcp.setNightsAlive(0);
-//				updateGlobalSpawnLocation(player);
+				updateGlobalSpawnLocation(player);
 				ItemStack[] endChestInv = player.getEnderChest().getContents();
 				List<hardcoreEnderChest> enderChestList = db.find(hardcoreEnderChest.class).where().eq("owner", player.getUniqueId()).findList();
 				hardcoreEnderChest[] enderChestArray = enderChestList.toArray(new hardcoreEnderChest[enderChestList.size()]);
 
             	World world = getServer().getWorlds().get(0);
             	
-                for (hardcoreEnderChest endChest : enderChestList){
+                for (hardcoreEnderChest endChest : enderChestArray){
                 	// turn all ender chests into regular chests
                     int bX = (int)endChest.getX();
                 	int bY = (int)endChest.getY();
@@ -82,18 +82,18 @@ public class AlmostHardcore extends JavaPlugin{
                 }
                 
                 for (ItemStack item : endChestInv){
-                	int chosenChestIdx = rnd.nextInt(enderChestArray.length);
-                	hardcoreEnderChest endChest = enderChestArray[chosenChestIdx];
-                    int bX = (int)endChest.getX();
-                	int bY = (int)endChest.getY();
-                	int bZ = (int)endChest.getZ();
-                	Block chestBlock = world.getBlockAt(bX,bY,bZ);
-                	Chest chest = (Chest) chestBlock.getState();
-                	Inventory chestInv = chest.getInventory();
-                	chestInv.addItem(item);
+                	// place each item from the player's end chest into one of the new chests at random
+                	if (item != null){
+	                	int chosenChestIdx = rnd.nextInt(enderChestArray.length);
+	                	hardcoreEnderChest endChest = enderChestArray[chosenChestIdx];
+	                	Chest chest = (Chest) world.getBlockAt((int)endChest.getX(),(int)endChest.getY(),(int)endChest.getZ()).getState();
+	                	Inventory chestInv = chest.getInventory();
+	                	chestInv.addItem(item);
+                	}
                 }
                 
                 for (hardcoreEnderChest endChest : enderChestList){
+                	// delete the old end chests from the database
                 	db.delete(endChest);
                 }
                 

--- a/AlmostHardcoreMinecraft/src/org/c0z3n/AlmostHardcore.java
+++ b/AlmostHardcoreMinecraft/src/org/c0z3n/AlmostHardcore.java
@@ -60,15 +60,15 @@ public class AlmostHardcore extends JavaPlugin{
 				hardcorePlayer hcp = db.find(hardcorePlayer.class).where().eq("id", player.getUniqueId()).findUnique();
 				hcp.addDeath();
 				hcp.setNightsAlive(0);
-				updateGlobalSpawnLocation(player);
+//				updateGlobalSpawnLocation(player);
 				ItemStack[] endChestInv = player.getEnderChest().getContents();
 				List<hardcoreEnderChest> enderChestList = db.find(hardcoreEnderChest.class).where().eq("owner", player.getUniqueId()).findList();
 				hardcoreEnderChest[] enderChestArray = enderChestList.toArray(new hardcoreEnderChest[enderChestList.size()]);
 
-            	World world = getServer().getWorlds().get(0);
             	
                 for (hardcoreEnderChest endChest : enderChestArray){
                 	// turn all ender chests into regular chests
+                	World world = getServer().getWorld(endChest.getWorld());
                     int bX = (int)endChest.getX();
                 	int bY = (int)endChest.getY();
                 	int bZ = (int)endChest.getZ();
@@ -86,6 +86,7 @@ public class AlmostHardcore extends JavaPlugin{
                 	if (item != null){
 	                	int chosenChestIdx = rnd.nextInt(enderChestArray.length);
 	                	hardcoreEnderChest endChest = enderChestArray[chosenChestIdx];
+	                	World world = getServer().getWorld(endChest.getWorld());
 	                	Chest chest = (Chest) world.getBlockAt((int)endChest.getX(),(int)endChest.getY(),(int)endChest.getZ()).getState();
 	                	Inventory chestInv = chest.getInventory();
 	                	chestInv.addItem(item);

--- a/AlmostHardcoreMinecraft/src/org/c0z3n/AlmostHardcore.java
+++ b/AlmostHardcoreMinecraft/src/org/c0z3n/AlmostHardcore.java
@@ -34,6 +34,8 @@ import org.bukkit.scheduler.BukkitScheduler;
 
 public class AlmostHardcore extends JavaPlugin{	
 	private com.avaje.ebean.EbeanServer db;
+
+	Random rnd = new Random();
 	
 	@Override
 	public void onEnable() {
@@ -60,12 +62,13 @@ public class AlmostHardcore extends JavaPlugin{
 				hcp.setNightsAlive(0);
 //				updateGlobalSpawnLocation(player);
 				ItemStack[] endChestInv = player.getEnderChest().getContents();
-				int numEnderChests = db.find(hardcoreEnderChest.class).where().eq("owner", player.getUniqueId()).findRowCount();
 				List<hardcoreEnderChest> enderChestList = db.find(hardcoreEnderChest.class).where().eq("owner", player.getUniqueId()).findList();
-				ItemStack[][] chunkedEndChestInv = splitInventory(endChestInv, numEnderChests);
-				int idx = 0;
+				hardcoreEnderChest[] enderChestArray = enderChestList.toArray(new hardcoreEnderChest[enderChestList.size()]);
+
+            	World world = getServer().getWorlds().get(0);
+            	
                 for (hardcoreEnderChest endChest : enderChestList){
-                	World world = getServer().getWorlds().get(0);
+                	// turn all ender chests into regular chests
                     int bX = (int)endChest.getX();
                 	int bY = (int)endChest.getY();
                 	int bZ = (int)endChest.getZ();
@@ -74,18 +77,26 @@ public class AlmostHardcore extends JavaPlugin{
                 	if(world.getBlockAt(bX + 1, bY, bZ).getType() != Material.CHEST && world.getBlockAt(bX - 1, bY, bZ).getType() != Material.CHEST && world.getBlockAt(bX, bY, bZ + 1).getType() != Material.CHEST && world.getBlockAt(bX, bY, bZ - 1).getType() != Material.CHEST){
                 		convertToMaterial = Material.CHEST;
                 	}
+                	chestBlock.breakNaturally(null);
                 	chestBlock.setType(convertToMaterial);
-                	
-                	Block newChestBlock = world.getBlockAt(bX,bY,bZ);
-                    if(newChestBlock.getState() instanceof Chest){
-                        Chest chest = (Chest) newChestBlock.getState();
-                        Inventory chestInv = chest.getInventory();
-//                        chestInv.setContents(chunkedEndChestInv[idx]);
-                        chestInv.setContents(endChestInv);
-                    }
-                    db.delete(endChest);
-                	idx = idx + 1;
                 }
+                
+                for (ItemStack item : endChestInv){
+                	int chosenChestIdx = rnd.nextInt(enderChestArray.length);
+                	hardcoreEnderChest endChest = enderChestArray[chosenChestIdx];
+                    int bX = (int)endChest.getX();
+                	int bY = (int)endChest.getY();
+                	int bZ = (int)endChest.getZ();
+                	Block chestBlock = world.getBlockAt(bX,bY,bZ);
+                	Chest chest = (Chest) chestBlock.getState();
+                	Inventory chestInv = chest.getInventory();
+                	chestInv.addItem(item);
+                }
+                
+                for (hardcoreEnderChest endChest : enderChestList){
+                	db.delete(endChest);
+                }
+                
 				player.getEnderChest().clear();
 				db.save(hcp);
 			}
@@ -236,27 +247,9 @@ public class AlmostHardcore extends JavaPlugin{
         list.add(hardcoreEnderChest.class);
         return list;
     }
-    
-    private ItemStack[][] splitInventory(ItemStack[] inventory, int numChunks) {
-    	
-        int chunkSize = (int)Math.ceil((double)inventory.length / numChunks);
-        ItemStack[][] output = new ItemStack[numChunks][];
-
-        for(int i = 0; i < numChunks; ++i) {
-            int start = i * chunkSize;
-            int length = Math.min(inventory.length - start, chunkSize);
-
-            ItemStack[] temp = new ItemStack[length];
-            System.arraycopy(inventory, start, temp, 0, length);
-            output[i] = temp;
-        }
-
-        return output;
-    }
 	
 	private int randCoord() {
 		//new random coordinate
-		Random rnd = new Random();
 		int randWindowSize = this.getConfig().getInt("RandomSpawnWindowSize");
 		return rnd.nextInt(randWindowSize) - randWindowSize/2;	
 	}

--- a/AlmostHardcoreMinecraft/src/org/c0z3n/AlmostHardcore.java
+++ b/AlmostHardcoreMinecraft/src/org/c0z3n/AlmostHardcore.java
@@ -10,6 +10,7 @@ import javax.persistence.PersistenceException;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
@@ -18,6 +19,8 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerBedEnterEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
@@ -77,7 +80,7 @@ public class AlmostHardcore extends JavaPlugin{
 				// I doubt it.
 				e.setCancelled(true);
 			}
-			
+
 			@EventHandler
 			public void onSpawn(PlayerRespawnEvent e) {
 				// things to do when a player spawns
@@ -85,6 +88,23 @@ public class AlmostHardcore extends JavaPlugin{
 				hardcorePlayer hcp = db.find(hardcorePlayer.class).where().eq("id", player.getUniqueId()).findUnique();
 				hcp.setLastSpawnId(db.find(hardcoreSpawn.class).findRowCount());
 				db.save(hcp);
+			}
+			
+			@EventHandler
+			public void onBlockPlace(BlockPlaceEvent e) {
+				if ( e.getBlockPlaced().getType() == Material.ENDER_CHEST){
+					hardcoreEnderChest newEndChest = new hardcoreEnderChest();
+					newEndChest.initFromPlaceEvent(e);
+					db.save(newEndChest);
+				}
+			}
+			
+			@EventHandler
+			public void onBlockBreak(BlockBreakEvent e) {
+				if ( e.getBlock().getType() == Material.ENDER_CHEST){
+					hardcoreEnderChest endChest = db.find(hardcoreEnderChest.class).where().eq("x", e.getBlock().getX()).eq("y", e.getBlock().getY()).eq("z", e.getBlock().getZ()).findUnique();
+					db.delete(endChest);
+				}
 			}
         
 		}, this);
@@ -182,6 +202,7 @@ public class AlmostHardcore extends JavaPlugin{
         // need to have a list.add() here for every class we want to be using in the database
         list.add(hardcorePlayer.class);
         list.add(hardcoreSpawn.class);
+        list.add(hardcoreEnderChest.class);
         return list;
     }
 	

--- a/AlmostHardcoreMinecraft/src/org/c0z3n/AlmostHardcore.java
+++ b/AlmostHardcoreMinecraft/src/org/c0z3n/AlmostHardcore.java
@@ -60,7 +60,7 @@ public class AlmostHardcore extends JavaPlugin{
 				hardcorePlayer hcp = db.find(hardcorePlayer.class).where().eq("id", player.getUniqueId()).findUnique();
 				hcp.addDeath();
 				hcp.setNightsAlive(0);
-//				updateGlobalSpawnLocation(player);
+				updateGlobalSpawnLocation(player);
 				ItemStack[] endChestInv = player.getEnderChest().getContents();
 				List<hardcoreEnderChest> enderChestList = db.find(hardcoreEnderChest.class).where().eq("owner", player.getUniqueId()).findList();
 				hardcoreEnderChest[] enderChestArray = enderChestList.toArray(new hardcoreEnderChest[enderChestList.size()]);

--- a/AlmostHardcoreMinecraft/src/org/c0z3n/hardcoreEnderChest.java
+++ b/AlmostHardcoreMinecraft/src/org/c0z3n/hardcoreEnderChest.java
@@ -1,0 +1,89 @@
+package org.c0z3n;
+
+
+
+
+
+import java.util.UUID;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.bukkit.event.block.BlockPlaceEvent;
+
+import com.avaje.ebean.validation.NotNull;
+
+@Entity()
+@Table(name="ahm_enderchests")
+public class hardcoreEnderChest {
+	
+	@Id
+	private int id;
+	
+	@NotNull
+	private UUID owner;
+	
+	@NotNull
+	private double x;
+	
+	@NotNull
+	private double y;
+	
+	@NotNull
+	private double z;
+	
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	public UUID getOwner() {
+		return owner;
+	}
+
+	public void setOwner(UUID owner) {
+		this.owner = owner;
+	}
+
+	public double getX() {
+		return x;
+	}
+
+	public void setX(double x) {
+		this.x = x;
+	}
+
+	public double getY() {
+		return y;
+	}
+
+	public void setY(double y) {
+		this.y = y;
+	}
+
+	public double getZ() {
+		return z;
+	}
+
+	public void setZ(double z) {
+		this.z = z;
+	}
+
+	public void coordsFromLocation(double x, double y, double z){
+		this.x = x;
+		this.y = y;
+		this.z = z;
+	}
+	
+	public void initFromPlaceEvent(BlockPlaceEvent e){
+		this.owner = e.getPlayer().getUniqueId();
+		this.x = e.getBlock().getX();
+		this.y = e.getBlock().getY();
+		this.z = e.getBlock().getZ();
+	}
+
+}

--- a/AlmostHardcoreMinecraft/src/org/c0z3n/hardcoreEnderChest.java
+++ b/AlmostHardcoreMinecraft/src/org/c0z3n/hardcoreEnderChest.java
@@ -33,6 +33,17 @@ public class hardcoreEnderChest {
 	@NotNull
 	private double z;
 	
+	@NotNull
+	private String world;
+
+	public String getWorld() {
+		return world;
+	}
+
+	public void setWorld(String world) {
+		this.world = world;
+	}
+
 	public int getId() {
 		return id;
 	}
@@ -84,6 +95,7 @@ public class hardcoreEnderChest {
 		this.x = e.getBlock().getX();
 		this.y = e.getBlock().getY();
 		this.z = e.getBlock().getZ();
+		this.world = e.getBlock().getWorld().getName();
 	}
 
 }


### PR DESCRIPTION
this implements dealing with ender chests when people die.

as a player plays, all ender chests they place in a life are logged. when they die, all the ender chests are converted into regular chests and their inventory is split at random between them. then, their ender chest inventory is cleared.

this branch is _probably_ at least as stable as the rest of the code at this point, may as well merge it right on in.

closes #3 
